### PR TITLE
fixed bug playing sound when breaking state stops and supporting NeoForge server-side communication

### DIFF
--- a/common/src/main/java/io/blodhgarm/door_knocking/DoorKnocking.java
+++ b/common/src/main/java/io/blodhgarm/door_knocking/DoorKnocking.java
@@ -17,11 +17,13 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
+import java.awt.event.InputEvent;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/common/src/main/java/io/blodhgarm/door_knocking/DoorKnocking.java
+++ b/common/src/main/java/io/blodhgarm/door_knocking/DoorKnocking.java
@@ -17,13 +17,11 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
-import java.awt.event.InputEvent;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/fabric/src/main/java/io/blodhgarm/door_knocking/fabric/DoorKnockingFabric.java
+++ b/fabric/src/main/java/io/blodhgarm/door_knocking/fabric/DoorKnockingFabric.java
@@ -18,8 +18,15 @@ public class DoorKnockingFabric implements ModInitializer {
         AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> DoorKnocking.attemptDoorInteraction(player, world, pos));
 
         var listener = new SimpleSynchronousResourceReloadListener() {
-            @Override public ResourceLocation getFabricId() { return DoorKnocking.CONFIG_HOLDER.getId(); }
-            @Override public void onResourceManagerReload(ResourceManager resourceManager) { DoorKnocking.CONFIG_HOLDER.onResourceManagerReload(resourceManager); }
+            @Override
+            public ResourceLocation getFabricId() {
+                return DoorKnocking.CONFIG_HOLDER.getId();
+            }
+
+            @Override
+            public void onResourceManagerReload(ResourceManager resourceManager) {
+                DoorKnocking.CONFIG_HOLDER.onResourceManagerReload(resourceManager);
+            }
         };
 
         ResourceManagerHelper.get(PackType.SERVER_DATA).registerReloadListener(listener);

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ minecraft_base_version=1.21
 yarn_mappings=1.21+build.7
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=io.blodhgarm
 archives_base_name=door_knocking
 

--- a/neoforge/src/main/java/io/blodhgarm/door_knocking/neoforge/DoorKnockingForge.java
+++ b/neoforge/src/main/java/io/blodhgarm/door_knocking/neoforge/DoorKnockingForge.java
@@ -1,7 +1,6 @@
 package io.blodhgarm.door_knocking.neoforge;
 
 import io.blodhgarm.door_knocking.DoorKnocking;
-import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -10,7 +9,7 @@ import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.AddReloadListenerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 
-@Mod(value = DoorKnocking.MODID, dist = Dist.CLIENT)
+@Mod(value = DoorKnocking.MODID)
 public class DoorKnockingForge {
 
     public DoorKnockingForge(IEventBus eventBus) {
@@ -22,6 +21,8 @@ public class DoorKnockingForge {
 
     public void onInitialize(FMLCommonSetupEvent event) {
         NeoForge.EVENT_BUS.addListener((PlayerInteractEvent.LeftClickBlock event1) -> {
+            if (event1.getLevel().isClientSide) return;
+
             if (event1.getAction().equals(PlayerInteractEvent.LeftClickBlock.Action.START))
                 DoorKnocking.attemptDoorInteraction(event1.getEntity(), event1.getLevel(), event1.getPos());
         });

--- a/neoforge/src/main/java/io/blodhgarm/door_knocking/neoforge/DoorKnockingForge.java
+++ b/neoforge/src/main/java/io/blodhgarm/door_knocking/neoforge/DoorKnockingForge.java
@@ -1,20 +1,14 @@
 package io.blodhgarm.door_knocking.neoforge;
 
 import io.blodhgarm.door_knocking.DoorKnocking;
-import net.minecraft.tags.BlockTags;
-import net.minecraft.world.level.Level;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
-import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.fml.loading.FMLPaths;
-import net.neoforged.neoforge.client.event.RegisterClientReloadListenersEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.AddReloadListenerEvent;
-import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
-import net.neoforged.neoforge.event.level.BlockEvent;
 
 @Mod(value = DoorKnocking.MODID, dist = Dist.CLIENT)
 public class DoorKnockingForge {
@@ -28,7 +22,8 @@ public class DoorKnockingForge {
 
     public void onInitialize(FMLCommonSetupEvent event) {
         NeoForge.EVENT_BUS.addListener((PlayerInteractEvent.LeftClickBlock event1) -> {
-            DoorKnocking.attemptDoorInteraction(event1.getEntity(), event1.getLevel(), event1.getPos());
+            if (event1.getAction().equals(PlayerInteractEvent.LeftClickBlock.Action.START))
+                DoorKnocking.attemptDoorInteraction(event1.getEntity(), event1.getLevel(), event1.getPos());
         });
     }
 }


### PR DESCRIPTION
Fixed an issue when stopped holding the button would make another knocking sound.
To do that, I've added an execption to only play the sound when the player-action is starting, not stopping (ba93873aac0e0fd636116eae37104a95e54eb566).

The issue appeared on Neoforge 1.21.1

EDIT: 
[I also fixed that the mod would not work on a NeoForge server. Fixing issue #4
](https://github.com/Dragon-Seeker/door-knocking/issues/4)
The fix is written in the networking-fix branch and documented in pr https://github.com/flashifloosh/door-knocking/pull/1


Because mentioned bugfixes make crutial changes, changed the mod-version to `1.0.2`
